### PR TITLE
repurpose

### DIFF
--- a/container_agent/docker_client.py
+++ b/container_agent/docker_client.py
@@ -22,8 +22,7 @@ from subprocess import Popen, PIPE
 log = logging.getLogger(__name__)
 
 
-DEFAULT_DOCKER_ENDPOINT = environ.get('DOCKER_HOST',
-                                      'unix:///var/run/docker.sock')
+DOCKER_HOST = environ.get('DOCKER_HOST', 'unix:///var/run/docker.sock')
 
 try:
     p = Popen('which docker', stdout=PIPE, stderr=PIPE, shell=True)
@@ -62,8 +61,8 @@ class CliDockerClientError(DockerClientError):
 class CliDockerClient(object):
     def __init__(self, docker=None, endpoint=None):
         super(CliDockerClient, self).__init__()
-        self.docker = docker or DEFAULT_DOCKER_CLI
-        self.endpoint = endpoint or DEFAULT_DOCKER_ENDPOINT
+        self.docker = docker if docker is not None else DEFAULT_DOCKER_CLI
+        self.endpoint = endpoint if endpoint is not None else DOCKER_HOST
 
     def cli(self, *args):
         command = (self.docker, '-H=%s' % self.endpoint) + tuple(args)

--- a/container_agent/docker_client.py
+++ b/container_agent/docker_client.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2014 Spotify AB. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from json import loads
+from os import environ
+from subprocess import Popen, PIPE
+
+
+log = logging.getLogger(__name__)
+
+
+DEFAULT_DOCKER_ENDPOINT = environ.get('DOCKER_HOST', 'unix:///var/run/docker.sock')
+
+try:
+    p = Popen('which docker', stdout=PIPE, stderr=PIPE, shell=True)
+    out, err = p.communicate()
+    if p.returncode:
+        raise Exception()
+    DEFAULT_DOCKER_CLI = out.strip()
+except:
+    DEFAULT_DOCKER_CLI = '/usr/bin/docker'
+
+
+def escape(word):
+    if ' ' in word:
+        return "'%s'" % (word, )
+    else:
+        return word
+
+
+class DockerClientError(Exception):
+    pass
+
+
+class CliDockerClientError(DockerClientError):
+    def __init__(self, command, code, out, err):
+        super(CliDockerClientError, self).__init__()
+        self.command = command
+        self.code = code
+        self.out = out
+        self.err = err
+
+    def __str__(self):
+        return 'docker command failed: %s (%d) out=(%s) err=(%s)' % (self.command, self.code, self.out, self.err)
+
+
+class CliDockerClient(object):
+    def __init__(self, docker=None, endpoint=None):
+        super(CliDockerClient, self).__init__()
+        self.docker = docker or DEFAULT_DOCKER_CLI
+        self.endpoint = endpoint or DEFAULT_DOCKER_ENDPOINT
+
+    def cli(self, *args):
+        command = (self.docker, '-H=%s' % self.endpoint) + tuple(args)
+        log.debug('cli: %s', command)
+        log.debug('cli: shell style: %s', ' '.join(escape(word) for word in command))
+        p = Popen(command, stdout=PIPE, stderr=PIPE)
+        out, err = p.communicate()
+        log.debug('%d %s %s', p.returncode, out, err)
+        return p.returncode, out, err
+
+    def cli_check(self, *args):
+        code, out, err = self.cli(*args)
+        if code:
+            raise CliDockerClientError(args, code, out, err)
+        return out
+
+    def inspect_container(self, container_id):
+        log.debug('inspect_container %s', container_id)
+        code, out, err = self.cli('inspect', container_id)
+        return loads(out)
+
+    def run(self, image=None, command=None, ports=None, name=None, volumes=None, env=None):
+        log.debug('run_daemon %s', image)
+        assert image
+        ports = ports or []
+        command = command or []
+        args = []
+        if ports:
+            args.extend(self.__port_arg(*port) for port in ports)
+        if name:
+            args.append('--name=%s' % (name, ))
+        if volumes:
+            args.extend('--volume=%s' % (volume, ) for volume in volumes)
+        if env:
+            args.extend('--env=%s' % (env, ) for env in env)
+        args.append(image)
+        args.extend(command)
+        return self.cli_check('run', '-d', *args).strip()
+
+    def start(self, container_id):
+        log.debug('start %s', container_id)
+        self.cli_check('start', container_id)
+
+    def stop(self, container_id):
+        log.debug('stop %s', container_id)
+        self.cli_check('stop', container_id)
+
+    def kill(self, container_id):
+        log.debug('kill %s', container_id)
+        self.cli_check('kill', container_id)
+
+    def destroy(self, container_id):
+        log.debug('destroy %s', container_id)
+        self.cli_check('rm', container_id)
+
+    def list_containers(self, needle=''):
+        if not needle:
+            return self.cli_check('ps', '-q').splitlines()
+        else:
+            lines = self.cli_check('ps').splitlines()[1:]
+            matches = [word for line in lines for word in line.split() if needle in word]
+            log.debug('list_containers: needle=%s, matches=%s', needle, matches)
+            return matches
+
+    def __port_arg(self, internal, external, proto):
+        es = external and ':%d' % (external, ) or ''
+        ps = proto and '/%s' % (proto, ) or ''
+        return '-p=%d%s%s' % (internal, es, ps)

--- a/container_agent/docker_client.py
+++ b/container_agent/docker_client.py
@@ -22,7 +22,8 @@ from subprocess import Popen, PIPE
 log = logging.getLogger(__name__)
 
 
-DEFAULT_DOCKER_ENDPOINT = environ.get('DOCKER_HOST', 'unix:///var/run/docker.sock')
+DEFAULT_DOCKER_ENDPOINT = environ.get('DOCKER_HOST',
+                                      'unix:///var/run/docker.sock')
 
 try:
     p = Popen('which docker', stdout=PIPE, stderr=PIPE, shell=True)
@@ -54,7 +55,8 @@ class CliDockerClientError(DockerClientError):
         self.err = err
 
     def __str__(self):
-        return 'docker command failed: %s (%d) out=(%s) err=(%s)' % (self.command, self.code, self.out, self.err)
+        return 'docker command failed: %s (%d) out=(%s) err=(%s)' % \
+               (self.command, self.code, self.out, self.err)
 
 
 class CliDockerClient(object):
@@ -66,7 +68,8 @@ class CliDockerClient(object):
     def cli(self, *args):
         command = (self.docker, '-H=%s' % self.endpoint) + tuple(args)
         log.debug('cli: %s', command)
-        log.debug('cli: shell style: %s', ' '.join(escape(word) for word in command))
+        log.debug('cli: shell style: %s', ' '.join(escape(word)
+                  for word in command))
         p = Popen(command, stdout=PIPE, stderr=PIPE)
         out, err = p.communicate()
         log.debug('%d %s %s', p.returncode, out, err)
@@ -83,7 +86,13 @@ class CliDockerClient(object):
         code, out, err = self.cli('inspect', container_id)
         return loads(out)
 
-    def run(self, image=None, command=None, ports=None, name=None, volumes=None, env=None):
+    def run(self,
+            image=None,
+            command=None,
+            ports=None,
+            name=None,
+            volumes=None,
+            env=None):
         log.debug('run_daemon %s', image)
         assert image
         ports = ports or []
@@ -122,8 +131,10 @@ class CliDockerClient(object):
             return self.cli_check('ps', '-q').splitlines()
         else:
             lines = self.cli_check('ps').splitlines()[1:]
-            matches = [word for line in lines for word in line.split() if needle in word]
-            log.debug('list_containers: needle=%s, matches=%s', needle, matches)
+            matches = [word for line in lines
+                       for word in line.split() if needle in word]
+            log.debug('list_containers: needle=%s, matches=%s',
+                      needle, matches)
             return matches
 
     def __port_arg(self, internal, external, proto):

--- a/container_agent/run_containers.py
+++ b/container_agent/run_containers.py
@@ -425,8 +425,8 @@ def RunContainersFromConfigFile(config_file, reload_interval, namespace):
                                                  all_volumes)
             CheckGroupWideConflicts(user_containers)
             RunContainers(user_containers, namespace)
-        except Exception, e:
-            log.error(e)
+        except Exception:
+            log.exception()
         finally:
             log.debug('sleeping %d seconds', reload_interval)
             time.sleep(float(reload_interval))

--- a/manifests/example.json
+++ b/manifests/example.json
@@ -1,5 +1,4 @@
 {
-  "version": "v1beta1",
   "volumes": [
     {"name": "vol1"},
     { "name": "vol2"}

--- a/manifests/simple-echo.yaml
+++ b/manifests/simple-echo.yaml
@@ -1,4 +1,3 @@
-version: v1beta1
 containers:
   - name: trusty-echo
     image: ubuntu:14.04

--- a/manifests/simple-echo.yaml
+++ b/manifests/simple-echo.yaml
@@ -1,0 +1,16 @@
+version: v1beta1
+containers:
+  - name: trusty-echo
+    image: ubuntu:14.04
+    command: ['sh', '-c', 'echo hello world | nc -p 4711 -l -k']
+    ports:
+      - name: nc-echo
+        hostPort: 14711
+        containerPort: 4711
+  - name: busybox-echo2
+    image: busybox
+    command: ['nc', '-p', '4711', '-l', '-l', '-e', 'echo', 'hello world!']
+    ports:
+      - name: nc-echo
+        hostPort: 14712
+        containerPort: 4711

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
   packages = ['container_agent'],
   entry_points = {
     'console_scripts': [
-      'container-agent = container_agent.run_containers:run'
+      'container-agent = container_agent.run_containers:main'
     ],
   },
 )

--- a/tests/run_containers_test.py
+++ b/tests/run_containers_test.py
@@ -10,26 +10,6 @@ from container_agent.run_containers import ConfigException
 
 class RunContainersTest(unittest.TestCase):
 
-    def testKnownVersion(self):
-        yaml_code = """
-      version: v1beta1
-      """
-        run_containers.CheckVersion(yaml.load(yaml_code))
-
-    def testNoVersion(self):
-        yaml_code = """
-      not_version: not valid
-      """
-        with self.assertRaises(ConfigException):
-            run_containers.CheckVersion(yaml.load(yaml_code))
-
-    def testUnknownVersion(self):
-        yaml_code = """
-      version: not valid
-      """
-        with self.assertRaises(ConfigException):
-            run_containers.CheckVersion(yaml.load(yaml_code))
-
     def testRfc1035Name(self):
         self.assertFalse(run_containers.IsRfc1035Name('1'))
         self.assertFalse(run_containers.IsRfc1035Name('123'))

--- a/tests/run_containers_test.py
+++ b/tests/run_containers_test.py
@@ -5,6 +5,7 @@
 import unittest
 import yaml
 from container_agent import run_containers
+from container_agent.run_containers import ConfigException
 
 
 class RunContainersTest(unittest.TestCase):
@@ -19,14 +20,14 @@ class RunContainersTest(unittest.TestCase):
         yaml_code = """
       not_version: not valid
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.CheckVersion(yaml.load(yaml_code))
 
     def testUnknownVersion(self):
         yaml_code = """
       version: not valid
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.CheckVersion(yaml.load(yaml_code))
 
     def testRfc1035Name(self):
@@ -61,14 +62,14 @@ class RunContainersTest(unittest.TestCase):
         yaml_code = """
       - notname: notgood
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumes(yaml.load(yaml_code))
 
     def testVolumeInvalidName(self):
         yaml_code = """
       - name: 123abc
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumes(yaml.load(yaml_code))
 
     def testVolumeDupName(self):
@@ -76,7 +77,7 @@ class RunContainersTest(unittest.TestCase):
       - name: abc123
       - name: abc123
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumes(yaml.load(yaml_code))
 
     def testContainerValidMinimal(self):
@@ -90,10 +91,6 @@ class RunContainersTest(unittest.TestCase):
         self.assertEqual(2, len(user))
         self.assertEqual('abc123', user[0].name)
         self.assertEqual('abc124', user[1].name)
-
-        infra = run_containers.LoadInfraContainers(user)
-        self.assertEqual(1, len(infra))
-        self.assertEqual('.net', infra[0].name)
 
     def testContainerValidFull(self):
         yaml_code = """
@@ -177,7 +174,7 @@ class RunContainersTest(unittest.TestCase):
       - notname: notgood
         image: foo/bar
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadUserContainers(yaml.load(yaml_code), [])
 
     def testContainerInvalidName(self):
@@ -185,7 +182,7 @@ class RunContainersTest(unittest.TestCase):
       - name: not_good
         image: foo/bar
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadUserContainers(yaml.load(yaml_code), [])
 
     def testContainerDupName(self):
@@ -195,7 +192,7 @@ class RunContainersTest(unittest.TestCase):
       - name: abc123
         image: foo/bar
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadUserContainers(yaml.load(yaml_code), [])
 
     def testContainerNoImage(self):
@@ -203,7 +200,7 @@ class RunContainersTest(unittest.TestCase):
       - name: abc123
         notimage: foo/bar
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadUserContainers(yaml.load(yaml_code), [])
 
     def testContainerWithoutCommand(self):
@@ -251,7 +248,7 @@ class RunContainersTest(unittest.TestCase):
         image: foo/bar
         workingDir: foo/bar
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadUserContainers(yaml.load(yaml_code), [])
 
     def testContainerWithoutPorts(self):
@@ -286,7 +283,7 @@ class RunContainersTest(unittest.TestCase):
       - name: 123abc
         containerPort: 123
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortDupName(self):
@@ -296,28 +293,28 @@ class RunContainersTest(unittest.TestCase):
       - name: abc123
         containerPort: 124
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortNoContainerPort(self):
         yaml_code = """
       - name: abc123
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortTooLowContainerPort(self):
         yaml_code = """
       - containerPort: 0
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortTooHighContainerPort(self):
         yaml_code = """
       - containerPort: 65536
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortWithHostPort(self):
@@ -334,7 +331,7 @@ class RunContainersTest(unittest.TestCase):
       - containerPort: 123
         hostPort: 0
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortTooHighHostPort(self):
@@ -342,7 +339,7 @@ class RunContainersTest(unittest.TestCase):
       - containerPort: 123
         hostPort: 65536
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortDupHostPort(self):
@@ -352,7 +349,7 @@ class RunContainersTest(unittest.TestCase):
       - containerPort: 124
         hostPort: 123
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testPortWithProtocolTcp(self):
@@ -378,7 +375,7 @@ class RunContainersTest(unittest.TestCase):
       - containerPort: 123
         protocol: IGMP
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadPorts(yaml.load(yaml_code), 'ctr_name')
 
     def testContainerWithoutMounts(self):
@@ -406,7 +403,7 @@ class RunContainersTest(unittest.TestCase):
         yaml_code = """
       - path: /mnt/vol1
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumeMounts(
                 yaml.load(yaml_code), ['vol1'], 'ctr_name')
 
@@ -415,7 +412,7 @@ class RunContainersTest(unittest.TestCase):
       - name: 1vol
         path: /mnt/vol1
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumeMounts(
                 yaml.load(yaml_code), ['1vol'], 'ctr_name')
 
@@ -424,7 +421,7 @@ class RunContainersTest(unittest.TestCase):
       - name: vol1
         path: /mnt/vol1
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumeMounts(
                 yaml.load(yaml_code), [], 'ctr_name')
 
@@ -432,7 +429,7 @@ class RunContainersTest(unittest.TestCase):
         yaml_code = """
       - name: vol1
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumeMounts(
                 yaml.load(yaml_code), ['vol1'], 'ctr_name')
 
@@ -441,7 +438,7 @@ class RunContainersTest(unittest.TestCase):
       - name: vol1
         path: mnt/vol1
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadVolumeMounts(
                 yaml.load(yaml_code), ['vol1'], 'ctr_name')
 
@@ -469,7 +466,7 @@ class RunContainersTest(unittest.TestCase):
         yaml_code = """
       - value: value
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadEnvVars(yaml.load(yaml_code), 'ctr_name')
 
     def testEnvInvalidKey(self):
@@ -477,14 +474,14 @@ class RunContainersTest(unittest.TestCase):
       - key: 1value
         value: value
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadEnvVars(yaml.load(yaml_code), 'ctr_name')
 
     def testEnvNoValue(self):
         yaml_code = """
       - key: key
       """
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.LoadEnvVars(yaml.load(yaml_code), 'ctr_name')
 
     def testFlagList(self):
@@ -520,19 +517,7 @@ class RunContainersTest(unittest.TestCase):
         c.ports = [(80, 81, '')]
         containers.append(c)
 
-        with self.assertRaises(SystemExit):
-            run_containers.CheckGroupWideConflicts(containers)
-
-    def testCheckGroupWideConflictsDupContainerPort(self):
-        containers = []
-        c = run_containers.Container('name1', 'ubuntu')
-        c.ports = [(80, 80, '')]
-        containers.append(c)
-        c = run_containers.Container('name1', 'ubuntu')
-        c.ports = [(81, 80, '')]
-        containers.append(c)
-
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(ConfigException):
             run_containers.CheckGroupWideConflicts(containers)
 
 


### PR DESCRIPTION
- Monitor manifest file(s)
- Recreate containers in response to manifest changes
- Kill containers in namespace that are not listed in manifest file(s)
- Internalize container keep-alive loop so that killing the container-agent lets you kill the containers.
- Use standard logging lib.
- Use docker client from docker-stress
- Remove infrastructure containers and container network stack sharing
- Remove manifest version check given substantial capability & behavior divergence
- Log errors instead of exiting on configuration validation failures.
